### PR TITLE
Populate library.properties url field

### DIFF
--- a/motorIR/library.properties
+++ b/motorIR/library.properties
@@ -5,5 +5,5 @@ maintainer=Eduardo Cáceres de la Calle <edcaceres95@hotmail.com>
 sentence= Controls 2 DC motors using IC
 paragraph=This library allows an Arduino board to control 2 DC motors using an IC Remote Control.
 category=Display
-url=*
+url=https://github.com/eduherminio/motorIR
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.